### PR TITLE
Fixes for PHP 8.1 compatibility

### DIFF
--- a/views/debug_toolbar.php
+++ b/views/debug_toolbar.php
@@ -36,7 +36,7 @@
 				<!-- Memory -->
 				<li id="memory" onclick="debugToolbar.show('debug-benchmarks'); return false;">
 					<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAAK/INwWK6QAAABl0RVh0U29mdHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAGvSURBVDjLpZO7alZREEbXiSdqJJDKYJNCkPBXYq12prHwBezSCpaidnY+graCYO0DpLRTQcR3EFLl8p+9525xgkRIJJApB2bN+gZmqCouU+NZzVef9isyUYeIRD0RTz482xouBBBNHi5u4JlkgUfx+evhxQ2aJRrJ/oFjUWysXeG45cUBy+aoJ90Sj0LGFY6anw2o1y/mK2ZS5pQ50+2XiBbdCvPk+mpw2OM/Bo92IJMhgiGCox+JeNEksIC11eLwvAhlzuAO37+BG9y9x3FTuiWTzhH61QFvdg5AdAZIB3Mw50AKsaRJYlGsX0tymTzf2y1TR9WwbogYY3ZhxR26gBmocrxMuhZNE435FtmSx1tP8QgiHEvj45d3jNlONouAKrjjzWaDv4CkmmNu/Pz9CzVh++Yd2rIz5tTnwdZmAzNymXT9F5AtMFeaTogJYkJfdsaaGpyO4E62pJ0yUCtKQFxo0hAT1JU2CWNOJ5vvP4AIcKeao17c2ljFE8SKEkVdWWxu42GYK9KE4c3O20pzSpyyoCx4v/6ECkCTCqccKorNxR5uSXgQnmQkw2Xf+Q+0iqQ9Ap64TwAAAABJRU5ErkJggg==" alt="memory">
-					<?php echo Text::bytes($benchmarks['application']['total_memory']) ?>
+					<?php echo Text::bytes($benchmarks['application']['total_memory'], '') ?>
 				</li>
 			<?php endif ?>
 
@@ -141,8 +141,8 @@
 							<td align="right"><?php echo $benchmark['count'] ?></td>
 							<td align="right"><?php echo sprintf('%.2f', $benchmark['avg_time'] * 1000) ?> ms</td>
 							<td align="right"><?php echo sprintf('%.2f', $benchmark['total_time'] * 1000) ?> ms</td>
-							<td align="right"><?php echo Text::bytes($benchmark['avg_memory']) ?></td>
-							<td align="right"><?php echo Text::bytes($benchmark['total_memory']) ?></td>
+							<td align="right"><?php echo Text::bytes($benchmark['avg_memory'], '') ?></td>
+							<td align="right"><?php echo Text::bytes($benchmark['total_memory'], '') ?></td>
 						</tr>
 						<?php endforeach; ?>
 					<?php endforeach; ?>
@@ -150,8 +150,8 @@
 							<th colspan="2" align="left">APPLICATION</th>
 							<th align="right"><?php echo sprintf('%.2f', $application['avg_time'] * 1000) ?> ms</th>
 							<th align="right"><?php echo sprintf('%.2f', $application['total_time'] * 1000) ?> ms</th>
-							<th align="right"><?php echo Text::bytes($application['avg_memory']) ?></th>
-							<th align="right"><?php echo Text::bytes($application['total_memory']) ?></th>
+							<th align="right"><?php echo Text::bytes($application['avg_memory'], '') ?></th>
+							<th align="right"><?php echo Text::bytes($application['total_memory'], '') ?></th>
 						</tr>
 				<?php else: ?>
 					<tr class="<?php echo Text::alternate('odd','even') ?>">
@@ -299,7 +299,7 @@
 				<?php endforeach; ?>
 				<tr align="left">
 					<th colspan="2">total</th>
-					<th><?php echo Text::bytes($total_size) ?></th>
+					<th><?php echo Text::bytes($total_size, '') ?></th>
 					<th><?php echo number_format($total_lines) ?></th>
 				</tr>
 			</table>


### PR DESCRIPTION
Koseven's Text::bytes() has a default second paramter specified as NULL which is then string compared. A fix should probably go into the Koseven branch (into Text::bytes()) aswell but this gets the DebugToolbar working again with PHP 8.1 by sending an empty string which doesn't fail on the string comparing and still evaluates to null.